### PR TITLE
Rework test assets file path creation

### DIFF
--- a/pkg/v1/ytbx/getting_test.go
+++ b/pkg/v1/ytbx/getting_test.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("getting stuff test cases", func() {
 	Context("Grabing values by path", func() {
 		It("should return the value referenced by the path", func() {
-			example := yml("../../../assets/examples/types.yml")
+			example := yml(assets("examples", "types.yml"))
 			Expect(grab(example, "/yaml/map/before")).To(BeEquivalentTo("after"))
 			Expect(grab(example, "/yaml/map/intA")).To(BeEquivalentTo(42))
 			Expect(grab(example, "/yaml/map/mapA")).To(BeEquivalentTo(yml(`{ key0: A, key1: A }`)))
@@ -39,18 +39,18 @@ var _ = Describe("getting stuff test cases", func() {
 			Expect(grab(example, "/yaml/simple-list/1")).To(BeEquivalentTo("B"))
 			Expect(grab(example, "/yaml/named-entry-list-using-key/3")).To(BeEquivalentTo(yml(`{ key: X }`)))
 
-			example = yml("../../../assets/bosh-yaml/manifest.yml")
+			example = yml(assets("bosh-yaml", "manifest.yml"))
 			Expect(grab(example, "/instance_groups/name=web/networks/name=concourse/static_ips/0")).To(BeEquivalentTo("XX.XX.XX.XX"))
 			Expect(grab(example, "/instance_groups/name=worker/jobs/name=baggageclaim/properties")).To(BeEquivalentTo(yml(`{}`)))
 		})
 
 		It("should return the whole tree if root is referenced", func() {
-			example := yml("../../../assets/examples/types.yml")
+			example := yml(assets("examples", "types.yml"))
 			Expect(grab(example, "/")).To(BeEquivalentTo(example))
 		})
 
 		It("should return useful error messages", func() {
-			example := yml("../../../assets/examples/types.yml")
+			example := yml(assets("examples", "types.yml"))
 			Expect(grabError(example, "/yaml/simple-list/-1")).To(BeEquivalentTo("failed to traverse tree, provided list index -1 is not in range: 0..4"))
 			Expect(grabError(example, "/yaml/does-not-exist")).To(BeEquivalentTo("no key 'does-not-exist' found in map, available keys: map, simple-list, named-entry-list-using-name, named-entry-list-using-key, named-entry-list-using-id"))
 			Expect(grabError(example, "/yaml/0")).To(BeEquivalentTo("failed to traverse tree, expected a list but found type map at /yaml"))
@@ -61,7 +61,7 @@ var _ = Describe("getting stuff test cases", func() {
 	})
 	Context("Trying to get values by path in an empty file", func() {
 		It("should return a not found key error", func() {
-			emptyFile := yml("../../../assets/examples/empty.yml")
+			emptyFile := yml(assets("examples", "empty.yml"))
 			Expect(grabError(emptyFile, "does-not-exist")).To(BeEquivalentTo("no key 'does-not-exist' found in map, available keys: "))
 		})
 	})

--- a/pkg/v1/ytbx/input_test.go
+++ b/pkg/v1/ytbx/input_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Input test cases", func() {
 				directory := vars["directory"]
 				filename := vars["filename"]
 
-				location := "../../../assets/" + directory + "/" + filename
+				location := assets(directory, filename)
 				if _, err := os.Stat(location); os.IsNotExist(err) {
 					w.WriteHeader(404)
 					fmt.Fprintf(w, "File not found: %s/%s", directory, filename)

--- a/pkg/v1/ytbx/path_test.go
+++ b/pkg/v1/ytbx/path_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func getExampleDocument() interface{} {
-	input, err := LoadFile(assetsDirectory + "/testbed/example.yml")
+	input, err := LoadFile(assets("testbed", "example.yml"))
 	Expect(err).To(BeNil())
 	Expect(len(input.Documents)).To(BeIdenticalTo(1))
 
@@ -149,7 +149,7 @@ var _ = Describe("path tests", func() {
 
 	Context("compare paths between two files", func() {
 		It("should find only duplicate paths", func() {
-			list, err := ComparePaths(assetsDirectory+"/testbed/sample_a.yml", assetsDirectory+"/testbed/sample_b.yml", GoPatchStyle, false)
+			list, err := ComparePaths(assets("testbed", "sample_a.yml"), assets("testbed", "sample_b.yml"), GoPatchStyle, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			listOfPaths := []Path{
@@ -180,7 +180,7 @@ var _ = Describe("path tests", func() {
 		})
 
 		It("should find only paths with the same value", func() {
-			list, err := ComparePaths(assetsDirectory+"/testbed/sample_a.yml", assetsDirectory+"/testbed/sample_b.yml", GoPatchStyle, true)
+			list, err := ComparePaths(assets("testbed", "sample_a.yml"), assets("testbed", "sample_b.yml"), GoPatchStyle, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			listOfPathsWithSameValue := []Path{

--- a/pkg/v1/ytbx/ytbx_suite_test.go
+++ b/pkg/v1/ytbx/ytbx_suite_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -36,8 +35,6 @@ import (
 	"github.com/homeport/ytbx/pkg/v1/ytbx"
 	yaml "gopkg.in/yaml.v2"
 )
-
-var assetsDirectory string
 
 var exampleTOML = `
 required = ["gopkg.in/fsnotify.v1"]
@@ -80,15 +77,25 @@ func TestYtbx(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	bunt.ColorSetting = bunt.OFF
-
-	_, file, _, ok := runtime.Caller(0)
-	Expect(ok).To(BeTrue())
-
-	dir, err := filepath.Abs(filepath.Dir(file) + "/../../../assets")
-	Expect(err).To(BeNil())
-
-	assetsDirectory = dir
+	bunt.TrueColorSetting = bunt.OFF
 })
+
+var _ = AfterSuite(func() {
+	bunt.ColorSetting = bunt.AUTO
+	bunt.TrueColorSetting = bunt.AUTO
+})
+
+func assets(pathElement ...string) string {
+	targetPath := filepath.Join(append(
+		[]string{"..", "..", "..", "assets"},
+		pathElement...,
+	)...)
+
+	abs, err := filepath.Abs(targetPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	return abs
+}
 
 func yml(input string) yaml.MapSlice {
 	// If input is a file loacation, load this as YAML


### PR DESCRIPTION
The name of the respective assets file used hardcoded slashes and was
done in each individual test file in slightly different styles.

Replace test file assets paths with one common function that creates the
respective absolute file path using Go libraries for file paths.