### PR TITLE
Add Go mod directory to cache directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 go:
 - 1.12.x
 
+cache:
+  directories:
+  - $GOPATH/pkg/mod
+
 os:
 - linux
 


### PR DESCRIPTION
The Go modules are downloaded for each run and in theory it should be
safe to keep them around for multiple runs.

Add the Go modules directory to the list of cached directories.