### PR TITLE
Migrate to Go YAML v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 binaries
+**/*.coverprofile

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/gonvenience/bunt v1.1.1
-	github.com/gonvenience/neat v1.1.0
+	github.com/gonvenience/neat v1.1.1
 	github.com/gonvenience/wrap v1.1.0
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74
-	gopkg.in/yaml.v2 v2.2.7
+	gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gonvenience/bunt v1.1.1 h1:isYxOpDqbRMOSRhZtoux1tYvhhQ/AIbVDFrs24l6t0M=
 github.com/gonvenience/bunt v1.1.1/go.mod h1:lsyhkmNpSAzhVx059BD0fQy5F29rWcS6AHb7UWNlT/s=
-github.com/gonvenience/neat v1.1.0 h1:xuEH2rYPedbIwuaYBJAtGwCJHwRlo8jF5PScLizuI5Y=
-github.com/gonvenience/neat v1.1.0/go.mod h1:Yb+9Jlr04pbtcRU8EGosVheOEBs//Lw/OXvgDyQfLTQ=
+github.com/gonvenience/neat v1.1.1 h1:uX5uxp3/KVMNgvfFceA5gkFeSofaqREIhOWepZafYlE=
+github.com/gonvenience/neat v1.1.1/go.mod h1:Yb+9Jlr04pbtcRU8EGosVheOEBs//Lw/OXvgDyQfLTQ=
 github.com/gonvenience/term v1.0.0 h1:joCB/j0Ngmdakd3muuLgAGPMf7DNKdoe708c1I6RiBs=
 github.com/gonvenience/term v1.0.0/go.mod h1:wohD4Iqso9Eol7qc2VnNhSFFhZxok5PvO7pZhdrAn4E=
 github.com/gonvenience/wrap v1.1.0 h1:d8gEZrXS/zg4BC1q0U4nHpPIh5k6muKpQ1+rQFBwpYc=

--- a/internal/cmd/restructure.go
+++ b/internal/cmd/restructure.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gonvenience/neat"
 	"github.com/homeport/ytbx/pkg/v1/ytbx"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 var inplace bool
@@ -53,7 +53,7 @@ var restructureCmd = &cobra.Command{
 		}
 
 		for i := range input.Documents {
-			input.Documents[i] = ytbx.RestructureObject(input.Documents[i])
+			ytbx.RestructureObject(input.Documents[i])
 		}
 
 		if inplace {
@@ -65,12 +65,12 @@ var restructureCmd = &cobra.Command{
 			var buf bytes.Buffer
 			writer := bufio.NewWriter(&buf)
 			for _, document := range input.Documents {
-				out, err := yaml.Marshal(document)
+				out, err := yamlv3.Marshal(document)
 				if err != nil {
 					return err
 				}
 
-				fmt.Fprint(writer, "---\n", string(out))
+				fmt.Fprint(writer, string(out))
 			}
 
 			writer.Flush()
@@ -83,7 +83,6 @@ var restructureCmd = &cobra.Command{
 					return err
 				}
 
-				bunt.Println("DimGray{*---*}")
 				fmt.Print(out)
 				fmt.Println()
 			}
@@ -104,8 +103,8 @@ func init() {
 }
 
 func renderLongDescription() string {
-	var data yaml.MapSlice
-	yaml.Unmarshal([]byte(`---
+	var data yamlv3.Node
+	yamlv3.Unmarshal([]byte(`---
 releases:
 - sha1: 5ab3b7e685ca18a47d0b4a16d0e3b60832b0a393
   name: binary-buildpack
@@ -114,7 +113,9 @@ releases:
 `), &data)
 
 	before, _ := neat.ToYAMLString(data)
-	after, _ := neat.ToYAMLString(ytbx.RestructureObject(data))
+
+	ytbx.RestructureObject(&data)
+	after, _ := neat.ToYAMLString(data)
 
 	return bunt.Sprintf(`Restructure the order of keys in YAML maps
 	

--- a/pkg/v1/ytbx/getting_test.go
+++ b/pkg/v1/ytbx/getting_test.go
@@ -23,6 +23,8 @@ package ytbx_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/homeport/ytbx/pkg/v1/ytbx"
 )
 
 var _ = Describe("getting stuff test cases", func() {
@@ -31,38 +33,44 @@ var _ = Describe("getting stuff test cases", func() {
 			example := yml(assets("examples", "types.yml"))
 			Expect(grab(example, "/yaml/map/before")).To(BeEquivalentTo("after"))
 			Expect(grab(example, "/yaml/map/intA")).To(BeEquivalentTo(42))
-			Expect(grab(example, "/yaml/map/mapA")).To(BeEquivalentTo(yml(`{ key0: A, key1: A }`)))
-			Expect(grab(example, "/yaml/map/listA")).To(BeEquivalentTo(list(`[ A, A, A ]`)))
-			Expect(grab(example, "/yaml/named-entry-list-using-name/name=B")).To(BeEquivalentTo(yml(`{ name: B }`)))
-			Expect(grab(example, "/yaml/named-entry-list-using-key/key=B")).To(BeEquivalentTo(yml(`{ key: B }`)))
-			Expect(grab(example, "/yaml/named-entry-list-using-id/id=B")).To(BeEquivalentTo(yml(`{ id: B }`)))
+			Expect(grab(example, "/yaml/map/mapA")).To(BeAsNode(yml(`{ key0: A, key1: A }`)))
+			Expect(grab(example, "/yaml/map/listA")).To(BeAsNode(list(`[ A, A, A ]`)))
+			Expect(grab(example, "/yaml/named-entry-list-using-name/name=B")).To(BeAsNode(yml(`{ name: B }`)))
+			Expect(grab(example, "/yaml/named-entry-list-using-key/key=B")).To(BeAsNode(yml(`{ key: B }`)))
+			Expect(grab(example, "/yaml/named-entry-list-using-id/id=B")).To(BeAsNode(yml(`{ id: B }`)))
 			Expect(grab(example, "/yaml/simple-list/1")).To(BeEquivalentTo("B"))
-			Expect(grab(example, "/yaml/named-entry-list-using-key/3")).To(BeEquivalentTo(yml(`{ key: X }`)))
+			Expect(grab(example, "/yaml/named-entry-list-using-key/3")).To(BeAsNode(yml(`{ key: X }`)))
 
 			example = yml(assets("bosh-yaml", "manifest.yml"))
 			Expect(grab(example, "/instance_groups/name=web/networks/name=concourse/static_ips/0")).To(BeEquivalentTo("XX.XX.XX.XX"))
-			Expect(grab(example, "/instance_groups/name=worker/jobs/name=baggageclaim/properties")).To(BeEquivalentTo(yml(`{}`)))
+			Expect(grab(example, "/instance_groups/name=worker/jobs/name=baggageclaim/properties")).To(BeAsNode(yml(`{}`)))
 		})
 
 		It("should return the whole tree if root is referenced", func() {
-			example := yml(assets("examples", "types.yml"))
-			Expect(grab(example, "/")).To(BeEquivalentTo(example))
+			file, err := ytbx.LoadFile(assets("examples", "types.yml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			document := file.Documents[0]
+			Expect(grab(document, "/")).To(BeAsNode(document.Content[0]))
 		})
 
 		It("should return useful error messages", func() {
 			example := yml(assets("examples", "types.yml"))
 			Expect(grabError(example, "/yaml/simple-list/-1")).To(BeEquivalentTo("failed to traverse tree, provided list index -1 is not in range: 0..4"))
 			Expect(grabError(example, "/yaml/does-not-exist")).To(BeEquivalentTo("no key 'does-not-exist' found in map, available keys: map, simple-list, named-entry-list-using-name, named-entry-list-using-key, named-entry-list-using-id"))
-			Expect(grabError(example, "/yaml/0")).To(BeEquivalentTo("failed to traverse tree, expected a list but found type map at /yaml"))
-			Expect(grabError(example, "/yaml/simple-list/foobar")).To(BeEquivalentTo("failed to traverse tree, expected a map but found type list at /yaml/simple-list"))
-			Expect(grabError(example, "/yaml/map/foobar=0")).To(BeEquivalentTo("failed to traverse tree, expected a complex-list but found type map at /yaml/map"))
+			Expect(grabError(example, "/yaml/0")).To(BeEquivalentTo("failed to traverse tree, expected list but found type map at /yaml"))
+			Expect(grabError(example, "/yaml/simple-list/foobar")).To(BeEquivalentTo("failed to traverse tree, expected map but found type list at /yaml/simple-list"))
+			Expect(grabError(example, "/yaml/map/foobar=0")).To(BeEquivalentTo("failed to traverse tree, expected complex-list but found type map at /yaml/map"))
 			Expect(grabError(example, "/yaml/named-entry-list-using-id/id=0")).To(BeEquivalentTo("there is no entry id=0 in the list"))
 		})
 	})
+
 	Context("Trying to get values by path in an empty file", func() {
 		It("should return a not found key error", func() {
 			emptyFile := yml(assets("examples", "empty.yml"))
-			Expect(grabError(emptyFile, "does-not-exist")).To(BeEquivalentTo("no key 'does-not-exist' found in map, available keys: "))
+			Expect(grabError(emptyFile, "/does-not-exist")).To(
+				BeEquivalentTo("failed to traverse tree, expected map but found type string at /"),
+			)
 		})
 	})
 })

--- a/pkg/v1/ytbx/input_test.go
+++ b/pkg/v1/ytbx/input_test.go
@@ -32,7 +32,6 @@ import (
 
 	. "github.com/gorilla/mux"
 	. "github.com/homeport/ytbx/pkg/v1/ytbx"
-	yaml "gopkg.in/yaml.v2"
 )
 
 var _ = Describe("Input test cases", func() {
@@ -41,10 +40,10 @@ var _ = Describe("Input test cases", func() {
 			doc0, doc1 := `{ "key": "value" }`, `[ { "foo": "bar" } ]`
 
 			documents, err := LoadDocuments([]byte(doc0 + "\n" + doc1))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(documents)).To(BeEquivalentTo(2))
-			Expect(documents[0]).To(BeEquivalentTo(yml(doc0)))
-			Expect(documents[1]).To(BeEquivalentTo(list(doc1)))
+			Expect(documents[0].Content[0]).To(BeAsNode(yml(doc0)))
+			Expect(documents[1].Content[0]).To(BeAsNode(list(doc1)))
 		})
 	})
 
@@ -102,16 +101,9 @@ var _ = Describe("Input test cases", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(documents)).To(BeEquivalentTo(1))
 
-			document := documents[0]
-
-			Expect(document).To(BeAssignableToTypeOf(yaml.MapSlice{}))
-			root := documents[0].(yaml.MapSlice)
-
-			Expect(root[0].Key).To(BeEquivalentTo("constraint"))
-			Expect(root[0].Value).To(BeAssignableToTypeOf([]yaml.MapSlice{}))
-
-			Expect(root[1].Key).To(BeEquivalentTo("override"))
-			Expect(root[1].Value).To(BeAssignableToTypeOf([]yaml.MapSlice{}))
+			rootMap := documents[0].Content[0]
+			Expect(rootMap.Content[0].Value).To(BeEquivalentTo("constraint"))
+			Expect(rootMap.Content[2].Value).To(BeEquivalentTo("override"))
 		})
 	})
 })

--- a/pkg/v1/ytbx/path_test.go
+++ b/pkg/v1/ytbx/path_test.go
@@ -25,11 +25,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/homeport/ytbx/pkg/v1/ytbx"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
-func getExampleDocument() interface{} {
+func getExampleDocument() *yamlv3.Node {
 	input, err := LoadFile(assets("testbed", "example.yml"))
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(len(input.Documents)).To(BeIdenticalTo(1))
 
 	return input.Documents[0]
@@ -68,7 +69,7 @@ var _ = Describe("path tests", func() {
 
 		It("should parse string with non-existing map elements", func() {
 			path, err := ParseDotStylePathString("yaml.update.newkey", getExampleDocument())
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(path).To(BeEquivalentTo(Path{DocumentIdx: 0, PathElements: []PathElement{
 				{Idx: -1, Key: "", Name: "yaml"},
 				{Idx: -1, Key: "", Name: "update"},
@@ -189,7 +190,8 @@ var _ = Describe("path tests", func() {
 						{Idx: -1, Key: "", Name: "yaml"},
 						{Idx: -1, Key: "", Name: "structure"},
 						{Idx: -1, Key: "", Name: "dot"},
-					}},
+					},
+				},
 				{
 					DocumentIdx: 0, PathElements: []PathElement{
 						{Idx: -1, Key: "", Name: "list"},

--- a/pkg/v1/ytbx/restructure_test.go
+++ b/pkg/v1/ytbx/restructure_test.go
@@ -25,51 +25,47 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/homeport/ytbx/pkg/v1/ytbx"
-	yaml "gopkg.in/yaml.v2"
 )
 
 var _ = Describe("Restructure order of map keys", func() {
 	Context("YAML MapSlice key reorderings of the MapSlice itself", func() {
 		It("should restructure Concourse root level keys", func() {
-			input := yml("{ groups: [], jobs: [], resources: [], resource_types: [] }")
-			output := RestructureObject(input).(yaml.MapSlice)
+			example := yml("{ groups: [], jobs: [], resources: [], resource_types: [] }")
+			RestructureObject(example)
 
-			keys, err := ListStringKeys(output)
-			Expect(err).To(BeNil())
+			keys, err := ListStringKeys(example)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(keys).To(BeEquivalentTo([]string{"jobs", "resources", "resource_types", "groups"}))
 		})
 
 		It("should restructure Concourse resource and resource_type keys", func() {
-			input := yml("{ source: {}, name: {}, type: {}, privileged: {} }")
-			output := RestructureObject(input).(yaml.MapSlice)
+			example := yml("{ source: {}, name: {}, type: {}, privileged: {} }")
+			RestructureObject(example)
 
-			keys, err := ListStringKeys(output)
-			Expect(err).To(BeNil())
+			keys, err := ListStringKeys(example)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(keys).To(BeEquivalentTo([]string{"name", "type", "source", "privileged"}))
 		})
 	})
 
 	Context("YAML MapSlice key reorderings of the MapSlice values", func() {
 		It("should restructure Concourse resource keys as part as part of a MapSlice value", func() {
-			input := yml("{ resources: [ { privileged: false, source: { branch: foo, paths: [] }, name: myname, type: mytype } ] }")
-			output := RestructureObject(input).(yaml.MapSlice)
+			example := yml("{ resources: [ { privileged: false, source: { branch: foo, paths: [] }, name: myname, type: mytype } ] }")
+			RestructureObject(example)
 
-			value := output[0].Value.([]interface{})
-			obj := value[0].(yaml.MapSlice)
-
-			keys, err := ListStringKeys(obj)
-			Expect(err).To(BeNil())
+			keys, err := ListStringKeys(example.Content[1].Content[0])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(keys).To(BeEquivalentTo([]string{"name", "type", "source", "privileged"}))
 		})
 	})
 
 	Context("Restructure code tries to rearrange even unknown keys", func() {
 		It("should reorder map keys in a somehow more readable way", func() {
-			input := yml(`{"list":["one","two","three"], "some":{"deep":{"structure":{"where":{"you":{"loose":{"focus":{"one":1,"two":2}}}}}}}, "name":"here", "release":"this"}`)
-			output := RestructureObject(input).(yaml.MapSlice)
+			example := yml(`{"list":["one","two","three"], "some":{"deep":{"structure":{"where":{"you":{"loose":{"focus":{"one":1,"two":2}}}}}}}, "name":"here", "release":"this"}`)
+			RestructureObject(example)
 
-			keys, err := ListStringKeys(output)
-			Expect(err).To(BeNil())
+			keys, err := ListStringKeys(example)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(keys).To(BeEquivalentTo([]string{"name", "release", "list", "some"}))
 		})
 	})


### PR DESCRIPTION
Introduce consistent usage of Go YAML v3 type `Node` in all functions.

Remove all old Go YAML v2 map item and slice references.

Rewrite the restructure code based on the previous style and ideas.

Rework test case setup to introduce YAML Node type.