### PR TITLE
Fix counter check bug in reorder code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/gonvenience/bunt v1.1.1
-	github.com/gonvenience/neat v1.1.1
+	github.com/gonvenience/neat v1.1.2
 	github.com/gonvenience/wrap v1.1.0
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/ginkgo v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gonvenience/bunt v1.1.1 h1:isYxOpDqbRMOSRhZtoux1tYvhhQ/AIbVDFrs24l6t0M=
 github.com/gonvenience/bunt v1.1.1/go.mod h1:lsyhkmNpSAzhVx059BD0fQy5F29rWcS6AHb7UWNlT/s=
-github.com/gonvenience/neat v1.1.1 h1:uX5uxp3/KVMNgvfFceA5gkFeSofaqREIhOWepZafYlE=
-github.com/gonvenience/neat v1.1.1/go.mod h1:Yb+9Jlr04pbtcRU8EGosVheOEBs//Lw/OXvgDyQfLTQ=
+github.com/gonvenience/neat v1.1.2 h1:jWWmBSnIQtwAzHs3rHhbYbWVB90ELPqnn5xy5/Ii80M=
+github.com/gonvenience/neat v1.1.2/go.mod h1:Yb+9Jlr04pbtcRU8EGosVheOEBs//Lw/OXvgDyQfLTQ=
 github.com/gonvenience/term v1.0.0 h1:joCB/j0Ngmdakd3muuLgAGPMf7DNKdoe708c1I6RiBs=
 github.com/gonvenience/term v1.0.0/go.mod h1:wohD4Iqso9Eol7qc2VnNhSFFhZxok5PvO7pZhdrAn4E=
 github.com/gonvenience/wrap v1.1.0 h1:d8gEZrXS/zg4BC1q0U4nHpPIh5k6muKpQ1+rQFBwpYc=

--- a/pkg/ytbx/restructure.go
+++ b/pkg/ytbx/restructure.go
@@ -88,15 +88,15 @@ func maxDepth(node *yamlv3.Node) (max int) {
 	return max
 }
 
-func countCommonKeys(keys []string, list []string) int {
-	counter, lookup := 0, lookupMap(keys)
+func countCommonKeys(keys []string, list []string) (counter int) {
+	lookup := lookupMap(keys)
 	for _, key := range list {
 		if _, ok := lookup[key]; ok {
 			counter++
 		}
 	}
 
-	return counter
+	return
 }
 
 func commonKeys(setA []string, setB []string) []string {
@@ -147,7 +147,7 @@ func reorderKeyValuePairsInMappingNodeContent(mappingNode *yamlv3.Node, keys []s
 func getSuitableReorderFunction(keys []string) func(*yamlv3.Node) {
 	topCandidateIdx, topCandidateHits := -1, -1
 	for idx, candidate := range knownKeyOrders {
-		if count := countCommonKeys(keys, candidate); count > topCandidateHits {
+		if count := countCommonKeys(keys, candidate); count > 0 && count > topCandidateHits {
 			topCandidateIdx = idx
 			topCandidateHits = count
 		}


### PR DESCRIPTION
The reorder code did not check whether the common keys function returned
a value greater than zero. If there are zero common keys, it should not
use that number 0 in the processing.

Fix counter check bug by adding another check for greater than zero.